### PR TITLE
correct include file names and config paths 

### DIFF
--- a/SW/MK64/HEXIWEAR_MK64/code/OLED/src/OLED_driver.c
+++ b/SW/MK64/HEXIWEAR_MK64/code/OLED/src/OLED_driver.c
@@ -38,7 +38,7 @@
 
 #include "HEXIWEAR_info.h"
 
-#include "OLED_Driver.h"
+#include "OLED_driver.h"
 #include "string.h"
 #include <stdlib.h>
 #include "error.h"
@@ -50,8 +50,8 @@
 
 #include "fsl_gpio_driver.h"
 
-#include "OLED_Defs.h"
-#include "OLED_Info.h"
+#include "OLED_defs.h"
+#include "OLED_info.h"
 
 #include "gui_resources.h"
 

--- a/SW/MK64/HEXIWEAR_MK64/code/apps/pedometer/Keynetik/inc/Keynetik_defs.h
+++ b/SW/MK64/HEXIWEAR_MK64/code/apps/pedometer/Keynetik/inc/Keynetik_defs.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "keynetik_types.h"
+#include "Keynetik_types.h"
 
 extern activitylevel_t
   keynetikActivityLevel;

--- a/SW/MK64/HEXIWEAR_MK64/code/apps/pedometer/Keynetik/inc/Keynetik_driver.h
+++ b/SW/MK64/HEXIWEAR_MK64/code/apps/pedometer/Keynetik/inc/Keynetik_driver.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "keynetik_info.h"
-#include "keynetik_defs.h"
+#include "Keynetik_info.h"
+#include "Keynetik_defs.h"
 
 /**
 * Initialize the Keynetik library.

--- a/SW/MK64/HEXIWEAR_MK64/code/apps/pedometer/src/pedometer_driver.c
+++ b/SW/MK64/HEXIWEAR_MK64/code/apps/pedometer/src/pedometer_driver.c
@@ -37,7 +37,7 @@
 
 #include "pedometer_driver.h"
 
-#include "keynetik_driver.h"
+#include "Keynetik_driver.h"
 #include "error.h"
 #include "sensor_driver.h"
 #include "gui_sensorTag.h"

--- a/SW/MK64/HEXIWEAR_MK64/code/extern_flash/src/FLASH_driver.c
+++ b/SW/MK64/HEXIWEAR_MK64/code/extern_flash/src/FLASH_driver.c
@@ -37,14 +37,14 @@
 
 #include "HEXIWEAR_info.h"
 
-#include "FLASH_Driver.h"
+#include "FLASH_driver.h"
 #include "generic_spi_driver.h"
 
 #include "error.h"
 #include "fsl_gpio_driver.h"
 #include "string.h"
 
-#include "FLASH_Info.h"
+#include "FLASH_info.h"
 
 /**
  * intern variables

--- a/SW/MK64/HEXIWEAR_MK64/code/intern_flash/src/flash_boot_kinetis.c
+++ b/SW/MK64/HEXIWEAR_MK64/code/intern_flash/src/flash_boot_kinetis.c
@@ -34,7 +34,7 @@
 
 
 /** include */
-#include "FLASH_boot_kinetis.h"
+#include "flash_boot_kinetis.h"
 #include "MK64F12.h"
 #include "MK64F12_cfg.h"
 #include "fsl_os_abstraction.h"

--- a/SW/MK64/HEXIWEAR_MK64/code/intf/inc/host_mcu_interface.h
+++ b/SW/MK64/HEXIWEAR_MK64/code/intf/inc/host_mcu_interface.h
@@ -39,7 +39,7 @@
 
 #include "fsl_os_abstraction.h"
 #include "KW40_UART.h"
-#include "hexiwear_info.h"
+#include "HEXIWEAR_info.h"
 
 /** packet constants */
 

--- a/SW/MK64/HEXIWEAR_MK64/code/protocols/I2C/inc/generic_i2c_info.h
+++ b/SW/MK64/HEXIWEAR_MK64/code/protocols/I2C/inc/generic_i2c_info.h
@@ -38,7 +38,7 @@
 #pragma once
 
 #include "MK64F12.h"
-#include "hexiwear_info.h"
+#include "HEXIWEAR_info.h"
 
 // interrupt numbers and values
 #define FSL_I2C_IRQn      ( HEXIWEAR_FS_I2C_IRQn )

--- a/SW/MK64/HEXIWEAR_MK64/kds/.cproject
+++ b/SW/MK64/HEXIWEAR_MK64/kds/.cproject
@@ -150,7 +150,7 @@
 							<tool command="${cross_prefix}${cross_cpp}${cross_suffix}" commandLinePattern="${COMMAND} ${cross_toolchain_flags} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} -Xlinker --start-group ${INPUTS} -Xlinker --end-group" id="ilg.gnuarmeclipse.managedbuild.cross.tool.c.linker.1681324840" name="Cross ARM C Linker" outputPrefix="" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.c.linker">
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.linker.gcsections.1850945755" name="Remove unused sections (-Xlinker --gc-sections)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.linker.gcsections" value="true" valueType="boolean"/>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.linker.scriptfile.1573832003" name="Script files (-T)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.linker.scriptfile" valueType="stringList">
-									<listOptionValue builtIn="false" value="../../code/Project_Settings/MK64_flash.ld"/>
+									<listOptionValue builtIn="false" value="../../code/project_settings/MK64_flash.ld"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.linker.libs.2061142742" name="Libraries (-l)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.linker.libs" valueType="libs">
 									<listOptionValue builtIn="false" value="PedometerLib"/>
@@ -364,4 +364,5 @@
 		</configuration>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>


### PR DESCRIPTION
Include names and config folders should be case sensitive in order to be able to compile under Linux